### PR TITLE
feat: add intent-aware micro planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@
 ---
 
 ## 🎉 News
+- [X] [2025.08.22]🎯📢 Introduced a lightweight micro planner that analyzes query intent and adapts retrieval strategy.
 - [X] [2025.08.12]🎯📢 🔍 RAG-Anything now features **VLM-Enhanced Query** mode! When documents include images, the system seamlessly integrates them into VLM for advanced multimodal analysis, combining visual and textual context for deeper insights.
 - [X] [2025.07.05]🎯📢 RAG-Anything now features a [context configuration module](docs/context_aware_processing.md), enabling intelligent integration of relevant contextual information to enhance multimodal content processing.
 - [X] [2025.07.04]🎯📢 🚀 RAG-Anything now supports multimodal query capabilities, enabling enhanced RAG with seamless processing of text, images, tables, and equations.
@@ -82,6 +83,7 @@ Users can query documents containing **interleaved text**, **visual diagrams**, 
 - **⚡ Adaptive Processing Modes** - Flexible MinerU-based parsing or direct multimodal content injection workflows
 - **📋 Direct Content List Insertion** - Bypass document parsing by directly inserting pre-parsed content lists from external sources
 - **🎯 Hybrid Intelligent Retrieval** - Advanced search capabilities spanning textual and multimodal content with contextual understanding
+- **🗺️ Intent-Aware Micro Planner** - Normalizes queries and adapts retrieval strategy based on inferred intent and resource budgets
 
 </div>
 
@@ -304,6 +306,7 @@ async def main():
         enable_image_processing=True,
         enable_table_processing=True,
         enable_equation_processing=True,
+        enable_micro_planner=True,
     )
 
     # Define LLM model function

--- a/examples/micro_planner_example.py
+++ b/examples/micro_planner_example.py
@@ -1,0 +1,35 @@
+"""Example demonstrating micro planner usage."""
+
+import asyncio
+from pathlib import Path
+import sys
+
+# Allow running without package installation
+sys.path.append(str(Path(__file__).parent.parent))
+
+from lightrag.utils import EmbeddingFunc
+from raganything import RAGAnything, RAGAnythingConfig
+
+
+def dummy_llm(prompt, **kwargs):
+    return "dummy response"
+
+
+def dummy_embed(texts):
+    return [[0.0, 0.0, 0.0] for _ in texts]
+
+
+async def main() -> None:
+    config = RAGAnythingConfig(enable_micro_planner=True)
+    rag = RAGAnything(
+        llm_model_func=dummy_llm,
+        embedding_func=EmbeddingFunc(dummy_embed, 3),
+        config=config,
+    )
+    await rag._ensure_lightrag_initialized()
+    await rag.aquery("Summarize the document content.")
+    await rag.aquery("What does figure 2 show?")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/raganything/config.py
+++ b/raganything/config.py
@@ -103,6 +103,33 @@ class RAGAnythingConfig:
     content_format: str = field(default=get_env_value("CONTENT_FORMAT", "minerU", str))
     """Default content format for context extraction when processing documents."""
 
+    # Micro Planner Configuration
+    # ---
+    enable_micro_planner: bool = field(
+        default=get_env_value("ENABLE_MICRO_PLANNER", False, bool)
+    )
+    """Enable the query micro planner."""
+
+    query_time_budget_ms: int = field(
+        default=get_env_value("QUERY_TIME_BUDGET_MS", 1000, int)
+    )
+    """Approximate time budget per query in milliseconds."""
+
+    memory_budget_gb: float = field(
+        default=get_env_value("MEMORY_BUDGET_GB", 2.0, float)
+    )
+    """Approximate memory budget in gigabytes for planning policies."""
+
+    default_rerank_top_k: int = field(
+        default=get_env_value("DEFAULT_RERANK_TOP_K", 5, int)
+    )
+    """Default rerank top_k used when planner does not specify one."""
+
+    enable_reflection: bool = field(
+        default=get_env_value("ENABLE_REFLECTION", False, bool)
+    )
+    """Enable answer reflection step after generation."""
+
     def __post_init__(self):
         """Post-initialization setup for backward compatibility"""
         # Support legacy environment variable names for backward compatibility

--- a/raganything/micro_planner.py
+++ b/raganything/micro_planner.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+"""Lightweight micro planner for query normalization and strategy selection."""
+
+from dataclasses import dataclass, field
+from typing import List, Dict, Tuple, Any
+import unicodedata
+import re
+
+
+@dataclass
+class IntentResult:
+    """Result of intent detection."""
+
+    intent: str
+    tags: List[str] = field(default_factory=list)
+    confidence: float = 0.0
+
+
+@dataclass
+class QueryPlan:
+    """Compiled plan for executing a query."""
+
+    retrieval_mode: str = "mix"
+    top_k: int = 5
+    rerank_top_k: int = 5
+    use_vlm: bool = False
+    feature_flags: Dict[str, bool] = field(
+        default_factory=lambda: {"image": True, "table": True, "equation": True}
+    )
+
+
+class MicroPlanner:
+    """Simple planner that prepares queries before passing to LightRAG."""
+
+    def __init__(self):
+        self.feature_flags = {"image": True, "table": True, "equation": True}
+
+    def normalize(self, text: str) -> str:
+        """Normalize input text using Unicode NFKC and whitespace collapse."""
+
+        normalized = unicodedata.normalize("NFKC", text).lower()
+        normalized = re.sub(r"\s+", " ", normalized).strip()
+        return normalized
+
+    def detect_intent(self, text: str) -> IntentResult:
+        """Very small rule based intent detector."""
+
+        lower = text.lower()
+        intent = "text"
+        tags: List[str] = []
+        if any(k in lower for k in ["figure", "image", "photo", "visual"]):
+            intent = "visual"
+        if "table" in lower:
+            intent = "table"
+        if any(k in lower for k in ["compare", "difference"]):
+            tags.append("compare")
+        return IntentResult(intent=intent, tags=tags, confidence=0.6)
+
+    def compile_strategy(self, intent: str, tags: List[str]) -> QueryPlan:
+        """Build a query plan from detected intent."""
+
+        plan = QueryPlan()
+        if intent == "visual":
+            plan.use_vlm = True
+            plan.retrieval_mode = "local"
+        elif intent == "table":
+            plan.retrieval_mode = "local"
+        else:
+            plan.retrieval_mode = "mix"
+        return plan
+
+    def apply_policies(self, plan: QueryPlan, budgets: Dict[str, Any]) -> QueryPlan:
+        """Apply simple resource aware policies to the plan."""
+
+        time_ms = budgets.get("time_ms", 1000)
+        if time_ms < 500:
+            plan.top_k = 3
+        memory_gb = budgets.get("memory_gb", 2.0)
+        if memory_gb < 1.0:
+            plan.feature_flags["image"] = False
+            plan.feature_flags["equation"] = False
+            self.feature_flags.update(plan.feature_flags)
+        return plan
+
+    def evaluate(self, query: str, answer: str, context: Dict[str, Any]) -> Dict[str, Any]:
+        """Placeholder evaluation hook."""
+
+        if not answer:
+            return {"degrade_reason": "empty_answer"}
+        return {"degrade_reason": None}
+
+    def plan(
+        self, query: str, budgets: Dict[str, Any] | None = None
+    ) -> Tuple[str, QueryPlan]:
+        """Entry point combining normalization, intent detection and policies."""
+
+        normalized = self.normalize(query)
+        intent = self.detect_intent(normalized)
+        plan = self.compile_strategy(intent.intent, intent.tags)
+        if budgets:
+            plan = self.apply_policies(plan, budgets)
+        return normalized, plan


### PR DESCRIPTION
## Summary
- add lightweight micro planner for query normalization, intent detection and budget-aware planning
- expose planner and budget controls in configuration and query pipeline
- document usage and provide micro planner example

## Testing
- `python -m pytest` *(fails: fixture 'file_path' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c51f4faa4c832fb527fd0e2bac9d24